### PR TITLE
Skeleton ZSH Completion

### DIFF
--- a/aur_package/_minirc
+++ b/aur_package/_minirc
@@ -1,0 +1,16 @@
+#compdef rc.d
+_minirc_commands(){
+   local -a _cmds
+   _cmds=(
+      'start:start a service'
+      'stop:stop a service'
+      'restart:restart a running service'
+      'list:list all services'
+      )
+   _describe 'command' _cmds
+}
+            
+_arguments -C -A "-*" \
+    '1:command:_minirc_commands' \
+    --help'[show basic usage]' \
+    --version'[show version information]' \


### PR DESCRIPTION
ToDo: Add (if possible) completion for available services and add contexts to them (only complete non-running services after having completed `start`, etc.)
